### PR TITLE
Add BM1370 test driver

### DIFF
--- a/ASIC-README
+++ b/ASIC-README
@@ -28,6 +28,7 @@ Currently supported devices include:
 - Onestring miner USB
 - Rockminer R-Box/RK-Box/T1/New R-Box
 - Spondoolies SP10, SP30
+- BM1370 test device
 
 
 No COM ports on windows or TTY devices will be used by cgminer as it

--- a/Makefile.am
+++ b/Makefile.am
@@ -194,6 +194,10 @@ if HAS_MINION
 cgminer_SOURCES += driver-minion.c
 endif
 
+if HAS_BM1370
+cgminer_SOURCES += driver-bm1370.c driver-bm1370.h
+endif
+
 if HAS_ANT_S1
 cgminer_SOURCES += driver-bitmain.c driver-bitmain.h
 endif

--- a/api.c
+++ b/api.c
@@ -29,7 +29,7 @@
 #if defined(USE_BFLSC) || defined(USE_AVALON) || defined(USE_AVALON2) || defined(USE_AVALON4) || \
   defined(USE_HASHFAST) || defined(USE_BITFURY) || defined(USE_BITFURY16) || defined(USE_BLOCKERUPTER) || defined(USE_KLONDIKE) || \
 	defined(USE_KNC) || defined(USE_BAB) || defined(USE_DRAGONMINT_T1) || defined(USE_DRILLBIT) || \
-	defined(USE_MINION) || defined(USE_COINTERRA) || defined(USE_BITMINE_A1) || \
+        defined(USE_MINION) || defined(USE_COINTERRA) || defined(USE_BITMINE_A1) || defined(USE_BM1370) || \
 	defined(USE_ANT_S1) || defined(USE_ANT_S2) || defined(USE_ANT_S3) || defined(USE_SP10) || \
 	defined(USE_SP30) || defined(USE_ICARUS) || defined(USE_HASHRATIO) || defined(USE_AVALON_MINER) || \
 	defined(USE_AVALON7) || defined(USE_AVALON8) || defined(USE_BITMAIN_SOC)
@@ -212,10 +212,13 @@ static const char *DEVICECODE = ""
 			"KnC "
 #endif
 #ifdef USE_MINION
-			"MBA "
+                        "MBA "
+#endif
+#ifdef USE_BM1370
+                        "B70 "
 #endif
 #ifdef USE_MODMINER
-			"MMQ "
+                        "MMQ "
 #endif
 #ifdef USE_COINTERRA
 			"CTA "

--- a/cgminer.c
+++ b/cgminer.c
@@ -131,6 +131,9 @@ char *curly = ":D";
 #ifdef USE_HASHFAST
 #include "driver-hashfast.h"
 #endif
+#ifdef USE_BM1370
+#include "driver-bm1370.h"
+#endif
 
 #if defined(USE_ANT_S1) || defined(USE_ANT_S2) || defined(USE_ANT_S3)
 #include "driver-bitmain.h"
@@ -2517,10 +2520,13 @@ static char *opt_verusage_and_exit(const char *extra)
 		"BaB "
 #endif
 #ifdef USE_MINION
-		"minion "
+                "minion "
+#endif
+#ifdef USE_BM1370
+                "bm1370 "
 #endif
 #ifdef USE_MODMINER
-		"modminer "
+                "modminer "
 #endif
 #ifdef USE_BITMINE_A1
 		"Bitmine.A1 "

--- a/configure.ac
+++ b/configure.ac
@@ -504,6 +504,18 @@ fi
 AM_CONDITIONAL([HAS_MINION], [test x$minion = xyes])
 
 
+bm1370="no"
+
+AC_ARG_ENABLE([bm1370],
+        [AC_HELP_STRING([--enable-bm1370],[Compile support for BM1370 ASICs test driver (default disabled)])],
+        [bm1370=$enableval]
+        )
+if test "x$bm1370" = xyes; then
+        AC_DEFINE([USE_BM1370], [1], [Defined to 1 if BM1370 ASIC support is wanted])
+        drivercount=x$drivercount
+fi
+AM_CONDITIONAL([HAS_BM1370], [test x$bm1370 = xyes])
+
 modminer="no"
 
 AC_ARG_ENABLE([modminer],
@@ -925,9 +937,15 @@ else
 fi
 
 if test "x$bitmine_A1" = xyes; then
-	echo "  Bitmine-A1.ASICs.....: Enabled"
+        echo "  Bitmine-A1.ASICs.....: Enabled"
 else
-	echo "  Bitmine-A1.ASICs.....: Disabled"
+        echo "  Bitmine-A1.ASICs.....: Disabled"
+fi
+
+if test "x$bm1370" = xyes; then
+        echo "  BM1370.ASICs.........: Enabled"
+else
+        echo "  BM1370.ASICs.........: Disabled"
 fi
 
 if test "x$dragonmint_t1" = xyes; then
@@ -979,7 +997,7 @@ else
 fi
 
 #Add any new device to this, along with a no on the end of the test
-if test "x$avalon$avalon2$avalon4$avalon7$avalon8$avalon_miner$bab$bflsc$bitforce$bitfury$bitfury16$bitmain_soc$blockerupter$hashfast$hashratio$icarus$klondike$knc$modminer$drillbit$minion$cointerra$bitmine_A1$ants1$ants2$ants3$sp10$sp30$dragonmint_t1" = xnononononononononononononononononononononononononononono; then
+if test "x$avalon$avalon2$avalon4$avalon7$avalon8$avalon_miner$bab$bflsc$bitforce$bitfury$bitfury16$bitmain_soc$blockerupter$hashfast$hashratio$icarus$klondike$knc$modminer$drillbit$minion$cointerra$bitmine_A1$bm1370$ants1$ants2$ants3$sp10$sp30$dragonmint_t1" = xnonononononononononononononononononononononononononononon; then
 	echo
 	AC_MSG_ERROR([No mining devices configured in])
 	echo

--- a/driver-bm1370.c
+++ b/driver-bm1370.c
@@ -1,0 +1,33 @@
+/*
+ * BM1370 test driver
+ */
+
+#include "config.h"
+#include "miner.h"
+#include <unistd.h>
+
+static void bm1370_detect(__maybe_unused bool hotplug)
+{
+    applog(LOG_INFO, "BM1370 test driver detected (hotplug=%d)", hotplug);
+}
+
+static bool bm1370_prepare(__maybe_unused struct thr_info *thr)
+{
+    return true;
+}
+
+static int64_t bm1370_scanwork(__maybe_unused struct thr_info *thr)
+{
+    cgsleep_ms(1000);
+    return 0;
+}
+
+struct device_drv bm1370_drv = {
+    .drv_id = DRIVER_bm1370,
+    .dname = "bm1370",
+    .name = "B70",
+    .drv_detect = bm1370_detect,
+    .thread_prepare = bm1370_prepare,
+    .hash_work = hash_driver_work,
+    .scanwork = bm1370_scanwork,
+};

--- a/driver-bm1370.h
+++ b/driver-bm1370.h
@@ -1,0 +1,8 @@
+#ifndef BM1370_H
+#define BM1370_H
+
+#include "miner.h"
+
+extern struct device_drv bm1370_drv;
+
+#endif /* BM1370_H */

--- a/miner.h
+++ b/miner.h
@@ -264,9 +264,10 @@ static inline int fsync (int fd)
 	DRIVER_ADD_COMMAND(hashratio) \
 	DRIVER_ADD_COMMAND(icarus) \
 	DRIVER_ADD_COMMAND(klondike) \
-	DRIVER_ADD_COMMAND(knc) \
-	DRIVER_ADD_COMMAND(minion) \
-	DRIVER_ADD_COMMAND(sp10) \
+        DRIVER_ADD_COMMAND(knc) \
+        DRIVER_ADD_COMMAND(minion) \
+        DRIVER_ADD_COMMAND(bm1370) \
+        DRIVER_ADD_COMMAND(sp10) \
 	DRIVER_ADD_COMMAND(sp30) \
 	DRIVER_ADD_COMMAND(bitmain_soc)
 


### PR DESCRIPTION
## Summary
- add a minimal BM1370 ASIC test driver
- enable configuring the new driver
- register bm1370 in driver enumeration and build system
- document bm1370 test device in ASIC-README

## Testing
- `./autogen.sh` *(fails: autoreconf not found)*
