### PR TITLE
Add additional automake files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ nbproject
 jansson.pc
 compat/jansson-2.9/src/jansson_config.h
 compat/jansson-2.9/jansson_private_config.h
+compat/jansson-2.9/jansson_private_config.h.in
 libtool
 ltmain.sh
 libtool.m4
@@ -38,6 +39,7 @@ install-sh
 stamp-h1
 cpuminer-config.h*
 compile
+test-driver
 config.log
 config.status
 config.guess


### PR DESCRIPTION
## Summary
- ignore the Jansson config template `jansson_private_config.h.in`
- ignore the autotools `test-driver` script

## Testing
- `make -n check` *(fails: No rule to make target 'check')*
- `make -n test` *(fails: No rule to make target 'test')*