### PR TITLE
Fix GCC 10 build issue with driver globals

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,7 @@ cgminer_SOURCES	+= logging.c
 cgminer_SOURCES	+= klist.h klist.c
 
 cgminer_SOURCES	+= noncedup.c
+cgminer_SOURCES	+= driver-stubs.c
 
 if NEED_FPGAUTILS
 cgminer_SOURCES += fpgautils.c fpgautils.h

--- a/driver-stubs.c
+++ b/driver-stubs.c
@@ -1,0 +1,93 @@
+#include "config.h"
+#include "miner.h"
+
+#ifndef USE_BITFORCE
+struct device_drv bitforce_drv;
+#endif
+#ifndef USE_MODMINER
+struct device_drv modminer_drv;
+#endif
+#ifndef USE_ANT_S1
+struct device_drv ants1_drv;
+#endif
+#ifndef USE_ANT_S2
+struct device_drv ants2_drv;
+#endif
+#ifndef USE_ANT_S3
+struct device_drv ants3_drv;
+#endif
+#ifndef USE_AVALON
+struct device_drv avalon_drv;
+#endif
+#ifndef USE_AVALON2
+struct device_drv avalon2_drv;
+#endif
+#ifndef USE_AVALON4
+struct device_drv avalon4_drv;
+#endif
+#ifndef USE_AVALON7
+struct device_drv avalon7_drv;
+#endif
+#ifndef USE_AVALON8
+struct device_drv avalon8_drv;
+#endif
+#ifndef USE_AVALON_MINER
+struct device_drv avalonm_drv;
+#endif
+#ifndef USE_BAB
+struct device_drv bab_drv;
+#endif
+#ifndef USE_BFLSC
+struct device_drv bflsc_drv;
+#endif
+#ifndef USE_BITFURY
+struct device_drv bitfury_drv;
+#endif
+#ifndef USE_BITFURY16
+struct device_drv bitfury16_drv;
+#endif
+#ifndef USE_BITMINE_A1
+struct device_drv bitmineA1_drv;
+#endif
+#ifndef USE_BLOCKERUPTER
+struct device_drv blockerupter_drv;
+#endif
+#ifndef USE_COINTERRA
+struct device_drv cointerra_drv;
+#endif
+#ifndef USE_DRAGONMINT_T1
+struct device_drv dragonmintT1_drv;
+#endif
+#ifndef USE_HASHFAST
+struct device_drv hashfast_drv;
+#endif
+#ifndef USE_DRILLBIT
+struct device_drv drillbit_drv;
+#endif
+#ifndef USE_HASHRATIO
+struct device_drv hashratio_drv;
+#endif
+#ifndef USE_ICARUS
+struct device_drv icarus_drv;
+#endif
+#ifndef USE_KLONDIKE
+struct device_drv klondike_drv;
+#endif
+#ifndef USE_KNC
+struct device_drv knc_drv;
+#endif
+#ifndef USE_MINION
+struct device_drv minion_drv;
+#endif
+#ifndef USE_SP10
+struct device_drv sp10_drv;
+#endif
+#ifndef USE_SP30
+struct device_drv sp30_drv;
+#endif
+#ifndef USE_BITMAIN_SOC
+struct device_drv bitmain_soc_drv;
+#endif
+#ifndef USE_BM1370
+struct device_drv bm1370_drv;
+#endif

--- a/miner.h
+++ b/miner.h
@@ -276,7 +276,7 @@ static inline int fsync (int fd)
 	ASIC_PARSE_COMMANDS(DRIVER_ADD_COMMAND)
 
 #define DRIVER_ENUM(X) DRIVER_##X,
-#define DRIVER_PROTOTYPE(X) struct device_drv X##_drv;
+#define DRIVER_PROTOTYPE(X) extern struct device_drv X##_drv;
 
 /* Create drv_driver enum from DRIVER_PARSE_COMMANDS macro */
 enum drv_driver {


### PR DESCRIPTION
## Summary
- declare driver globals as extern
- add stubs for drivers that are not compiled
- include new stub file in build

## Testing
- `./autogen.sh`
- `./configure --enable-bm1370`
- `make`