### PR TITLE
Automate driver stub generation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,7 @@ cgminer_SOURCES	+= logging.c
 cgminer_SOURCES	+= klist.h klist.c
 
 cgminer_SOURCES	+= noncedup.c
+cgminer_SOURCES	+= driver-stubs.c
 
 if NEED_FPGAUTILS
 cgminer_SOURCES += fpgautils.c fpgautils.h

--- a/driver-stubs.c
+++ b/driver-stubs.c
@@ -1,0 +1,14 @@
+#include "config.h"
+#include "miner.h"
+
+/*
+ * Provide weak definitions for driver structures when their real
+ * implementations aren't compiled. Using the DRIVER_PARSE_COMMANDS macro
+ * keeps this list automatically in sync with miner.h.
+ */
+
+#define DRIVER_WEAK_DEF(X) \
+    struct device_drv X##_drv __attribute__((weak));
+
+DRIVER_PARSE_COMMANDS(DRIVER_WEAK_DEF)
+

--- a/miner.h
+++ b/miner.h
@@ -276,7 +276,7 @@ static inline int fsync (int fd)
 	ASIC_PARSE_COMMANDS(DRIVER_ADD_COMMAND)
 
 #define DRIVER_ENUM(X) DRIVER_##X,
-#define DRIVER_PROTOTYPE(X) struct device_drv X##_drv;
+#define DRIVER_PROTOTYPE(X) extern struct device_drv X##_drv;
 
 /* Create drv_driver enum from DRIVER_PARSE_COMMANDS macro */
 enum drv_driver {


### PR DESCRIPTION
## Summary
- provide weak definitions of driver structures using DRIVER_PARSE_COMMANDS
- rely on linker to use the real driver when built

## Testing
- `./autogen.sh`
- `./configure --enable-bm1370`
- `make`
